### PR TITLE
Remove newlines from elements in signature

### DIFF
--- a/cz_nia/wsse/signature.py
+++ b/cz_nia/wsse/signature.py
@@ -46,6 +46,14 @@ def _signature_prepare(envelope, key, sign_method=xmlsec.Transform.RSA_SHA1):
     ctx.key = key
     _sign_node(ctx, signature, envelope.find(QName(soap_env, 'Body')))
     _sign_node(ctx, signature, security.find(QName(ns.WSU, 'Timestamp')))
+
+    # Remove newlines from signature...
+    for element in signature.iter():
+        if element.text is not None and '\n' in element.text:
+            element.text = element.text.replace('\n', '')
+        if element.tail is not None and '\n' in element.tail:
+            element.tail = element.tail.replace('\n', '')
+
     ctx.sign(signature)
 
     # Place the X509 data inside a WSSE SecurityTokenReference within

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [isort]
 line_length = 120
 known_third_party = xmlsec
+known_first_party = cz_nia
 combine_as_imports = True
 multi_line_output = 0
 


### PR DESCRIPTION
The newlines are replaced on the NIA side and thus the verification of
signature fails.